### PR TITLE
Support more granular AIR SDK versions

### DIFF
--- a/src/main/java/com/yelbota/plugins/adt/DependencyAdtMojo.java
+++ b/src/main/java/com/yelbota/plugins/adt/DependencyAdtMojo.java
@@ -23,6 +23,8 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 
 @Mojo(name = "dependency")
 public class DependencyAdtMojo extends AbstractAdtMojo {
@@ -104,8 +106,13 @@ public class DependencyAdtMojo extends AbstractAdtMojo {
     }
 
     protected Float getVersionNumber(String version) {
-        String preparedVersionString = version.replaceAll("[^\\d.]", "");
-
-        return Float.valueOf(preparedVersionString);
+        String preparedVersion = version.replaceAll("[^\\d.]", "");
+        Pattern pattern = Pattern.compile("^(\\d+\\.\\d+).*");
+        Matcher matcher = pattern.matcher(preparedVersion);
+        if(!matcher.matches()) {
+            getLog().debug("Invalid version string " + preparedVersion);
+            return null;
+        }
+        return Float.valueOf(matcher.group(1));
     }
 }

--- a/src/test/java/com/yelbota/plugins/adt/DependencyAdtMojoTest.java
+++ b/src/test/java/com/yelbota/plugins/adt/DependencyAdtMojoTest.java
@@ -94,4 +94,12 @@ public class DependencyAdtMojoTest {
         Assert.assertEquals(p, DependencyAdtMojo.TBZ2);
     }
 
+    @Test
+    public void getVersionNumberTest() throws Exception {
+        DependencyAdtMojo adtMojo = new DependencyAdtMojo();
+        Assert.assertEquals(adtMojo.getVersionNumber("3.4"), Float.valueOf("3.4"));
+        Assert.assertEquals(adtMojo.getVersionNumber("4.0"), Float.valueOf("4.0"));
+        Assert.assertEquals(adtMojo.getVersionNumber("14.0.0.76"), Float.valueOf("14.0"));
+    }
+
 }


### PR DESCRIPTION
This is to allow one to use more 'precise' SDK versions as Adobe tends to release beta builds within the same major.minor version (for instance 14.0.0.73). Code-wise, the `getVersionNumber()` method has the necessary logic to only extract major/minor to build a float out of it.
